### PR TITLE
Adjustments to Card Layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -201,7 +201,7 @@ img{
         grid-template-columns: repeat(auto-fill, minmax(20%, 1fr)); /* 5 cards */
       }
       .boxTemplate p {
-        font-size: clamp(1.5rem, 2vw, 2rem);
+        font-size: clamp(1.5rem, 3.5vw, 3rem);
       }
       #keyboard {
         width: 60%;
@@ -218,7 +218,7 @@ img{
         grid-template-columns: repeat(auto-fill, minmax(25%, 1fr)); /* 4 cards */
       }
       .boxTemplate p {
-        font-size: clamp(1.25rem, 4vw, 2.5rem);
+        font-size: clamp(1.25rem, 4.5vw, 2.5rem);
       }
       #keyboard {
         width: 80%;

--- a/css/style.css
+++ b/css/style.css
@@ -57,6 +57,7 @@ h1, h2, h3, p{
   display: grid;
   place-items: center;
   grid-template-rows: 1fr 1fr;
+  padding: 0;
 }
 .boxTemplate p {
   font-size: clamp(1.8rem, 1.8vw, 3rem);

--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,7 @@ h1{
   font-style: italic;
   letter-spacing: 1px;
   font-size: 3rem;
+  padding: 0 2vw;
 }
 
 html{
@@ -39,19 +40,16 @@ html{
 h1, h2, h3, p{
   text-align: center;
 }
-p {
-  font-size: 2rem;
-}
 
 #mainContainer{
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10%, 1fr)); /* 10 cards */
   justify-content: center;
+  padding: 0 2vw;
 }
 .boxTemplate {
   text-align: center;
   border: .1rem solid black;
-  flex-basis: 10%;
   height: 16rem;
   font-size: 1.6rem;
   border-radius: 5px;
@@ -59,6 +57,9 @@ p {
   display: grid;
   place-items: center;
   grid-template-rows: 1fr 1fr;
+}
+.boxTemplate p {
+  font-size: clamp(1.8rem, 1.8vw, 3rem);
 }
 
 
@@ -163,9 +164,21 @@ img{
 /******************************************
 /* ADDITIONAL STYLES
 /********************************************/
-
-
+@media screen and (max-width: 1000px){
+  #mainContainer{
+    grid-template-columns: repeat(auto-fill, minmax(14%, 1fr)); /* 7 cards */
+  }
+  .boxTemplate{
+    height: 13rem;
+  }
+  .boxTemplate p {
+    font-size: clamp(2rem, 2.5vw, 3rem);
+  }
+}
 @media screen and (max-width: 800px){
+      #mainContainer{
+        grid-template-columns: repeat(auto-fill, minmax(15%, 1fr)); /* 6 cards */
+      }
       .boxTemplate{
         height: 10rem;
       }
@@ -174,7 +187,7 @@ img{
         width: auto;
       }
       p {
-        font-size: 2rem;
+        font-size: clamp(1.8rem, 2.5vw, 3rem);
       }
       #customInputLabel{
         font-size: 3rem;
@@ -184,8 +197,11 @@ img{
       }
     }
     @media screen and (max-width: 600px) {
-      .boxTemplate {
-        flex-basis: 15%;
+      #mainContainer{
+        grid-template-columns: repeat(auto-fill, minmax(20%, 1fr)); /* 5 cards */
+      }
+      .boxTemplate p {
+        font-size: clamp(1.5rem, 2vw, 2rem);
       }
       #keyboard {
         width: 60%;
@@ -199,12 +215,20 @@ img{
         width: 100%;
       }
       #mainContainer{
-        justify-content: space-around;
+        grid-template-columns: repeat(auto-fill, minmax(25%, 1fr)); /* 4 cards */
       }
-      .boxTemplate {
-        flex-basis: 23%;
+      .boxTemplate p {
+        font-size: clamp(1.25rem, 4vw, 2.5rem);
       }
       #keyboard {
         width: 80%;
       }
-}
+    }
+    @media screen and (max-width: 300px) {
+      #mainContainer{
+        grid-template-columns: repeat(auto-fill, minmax(50%, 1fr)); /* 2 cards */
+      }
+      .boxTemplate p {
+        font-size: clamp(1rem, 8vw, 2.5rem);
+      }
+    }


### PR DESCRIPTION
PR for https://github.com/XollabOS/talktometechnology/issues/52.

This PR makes the following changes:
- Change layout of #mainContainer from flex to grid to force equal card widths
- Add left/right padding to h1 and #mainContainer to improve spacing from edge
- Change to variable font sizes for text on cards
- Change # of cards to display per row on existing media queries at the 400, 500, and 800px breakpoints
- Add media queries at the <1000px and <300px breakpoints to update the number cards displayed per row.
  - The <1000px breakpoint was added because the layout was slightly awkward until it reached the 800px breakpoint after adding variable font sizes.
  - The <300px breakpoint was added to add support for super small screens.
- To all media queries adjust font-size for the text on cards to prevent overflow.


Tested on Firefox, Chrome, Edge & the following viewports:


<table>
    <tr>
        <td></td>
        <th>Current</th>
        <th>Pull Request</th>
    <tr>
    <tr>
        <td>Nokia 8110 4G (vp: 240 x 320)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804621-d9752508-28f9-4552-9a3a-9f130091fdea.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804638-9ea7dfc1-36f4-4592-80fe-69ed601198b0.png'></td>
    </tr>
    <tr>
        <td>iPhone 5 (vp: 320 x 568)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804622-ba55ca55-a602-4ef2-9bf0-9adf6c178e0c.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804640-05eb423e-35db-4f88-8011-a117253675e0.png'></td>
    </tr>
    <tr>
        <td>iPhone 5 landscape (vp: 320 x 568)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804623-e254314c-6549-4647-b2f6-53dd412ce241.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804641-8197a28c-db0b-4135-a55f-8bef1dfa4776.png'></td>
    </tr>
    <tr>
        <td>iPhone 6/7/8 (vp: 414 x 736)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804624-1f983a08-57de-453a-868a-dc365c45d031.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804642-a49f3827-9cd5-4501-8b35-a3e976713c1b.png'></td>
    </tr>
    <tr>
        <td>iPhone 6/7/8 in landscape (vp: 736 x 414)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804629-c77980e8-a907-4f9c-ae2f-64e83c20c62a.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804645-719b5e9a-0753-4fbc-a727-372a6c590d6b.png'></td>
    </tr>
    <tr>
        <td>iPad (vp: 810 x 1080)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166806196-6efb5a72-994b-486b-9ae8-2fc54c072cc8.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804649-51f5cbda-ecc3-4e13-a9bc-5311b215abdb.png'></td>
    </tr>
    <tr>
        <td>Laptop (vp: 1280 x 950)</td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804637-ce218a4e-686b-4376-9a66-38fdcdd04ead.png'></td>
        <td width='45%'> <img src='https://user-images.githubusercontent.com/26422273/166804619-6d678de7-563d-4098-94fe-f9132504364b.png'></td>
    </tr>
<table>



